### PR TITLE
Rename CLI to filez-sync and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# File-sync
+# filez-sync
 
-A standalone Go tool for **bidirectional file synchronization** with proper **3-way merges** for Markdown (or any other text) files, designed to replace `unison` for cases where you need:
+`filez-sync` is a standalone Go tool for **bidirectional file synchronization** with proper **3-way merges** for Markdown (or any other text) files, designed to replace `unison` for cases where you need:
 
 * Persistent merge history (per-file ancestor snapshots)
 * Automatic use of `diff3` for conflict resolution
@@ -25,21 +25,21 @@ Tested for syncing two Obsidian vaults across directories, but works for any two
 ## Installation
 
 ### Prerequisites
-- Go 1.22+ (tested on Linux, macOS)
+- Go 1.24+ (tested on Linux, macOS)
 - (Optional) GNU `diff3` in `PATH` for better merge quality
 
 ```bash
-go install ./...
-````
+go install ./cmd/filez-sync
+```
 
-This will produce a binary `obsidian-3way-sync`.
+This will produce a binary `filez-sync`.
 
 ---
 
 ## Usage
 
 ```bash
-file-sync /path/to/vault_a /path/to/vault_b \
+filez-sync /path/to/vault_a /path/to/vault_b \
   --state-dir /path/to/state \
   --include "*.md"
 ```
@@ -76,7 +76,7 @@ file-sync /path/to/vault_a /path/to/vault_b \
 ## Example
 
 ```bash
-obsidian-3way-sync \
+filez-sync \
   ~/Documents/ObsidianVault \
   /mnt/backup/ObsidianVault \
   --state-dir ~/.obsidian-sync-state

--- a/cmd/filez-sync/main.go
+++ b/cmd/filez-sync/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"syncmd/internal/syncmd"
+	syncmd "github.com/MarkoPoloResearchLab/file_sync"
 )
 
 func main() {
@@ -19,7 +19,7 @@ func main() {
 	flag.Parse()
 
 	if flag.NArg() != 2 {
-		fmt.Fprintln(os.Stderr, "usage: syncmd [--state-dir DIR] [--include GLOB] [--no-backups] <root_a> <root_b>")
+		fmt.Fprintln(os.Stderr, "usage: filez-sync [--state-dir DIR] [--include GLOB] [--no-backups] <root_a> <root_b>")
 		os.Exit(2)
 	}
 
@@ -56,11 +56,10 @@ func main() {
 
 	result, runErr := syncmd.RunSync(options)
 	if runErr != nil {
-			fmt.Fprintln(os.Stderr, runErr.Error())
-			os.Exit(1)
+		fmt.Fprintln(os.Stderr, runErr.Error())
+		os.Exit(1)
 	}
 
 	fmt.Printf("changed=%d; actions=%v; diff3=%s\n",
 		result.ChangedFileCount, result.ActionCounters, map[bool]string{true: "yes", false: "no"}[result.Diff3Available])
 }
-

--- a/merge.go
+++ b/merge.go
@@ -8,10 +8,10 @@ import (
 )
 
 type mergeInputs struct {
-	BaseBytes    []byte
-	SideABytes   []byte
-	SideBBytes   []byte
-	UseDiff3     bool
+	BaseBytes  []byte
+	SideABytes []byte
+	SideBBytes []byte
+	UseDiff3   bool
 }
 
 func mergeThreeWay(inputs mergeInputs) ([]byte, bool) {
@@ -45,7 +45,7 @@ func mergeWithDiff3(base []byte, sideA []byte, sideB []byte) ([]byte, bool) {
 	if lookupErr != nil {
 		return nil, false
 	}
-	tempDir, tempErr := os.MkdirTemp("", "syncmd-merge-*")
+	tempDir, tempErr := os.MkdirTemp("", "filez-sync-merge-*")
 	if tempErr != nil {
 		return nil, false
 	}
@@ -75,4 +75,3 @@ func mergeWithDiff3(base []byte, sideA []byte, sideB []byte) ([]byte, bool) {
 	}
 	return nil, false
 }
-

--- a/sync_test.go
+++ b/sync_test.go
@@ -6,11 +6,12 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newTempDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "syncmd-test-*")
+	dir, err := os.MkdirTemp("", "filez-sync-test-*")
 	if err != nil {
 		t.Fatalf("mkdir temp: %v", err)
 	}
@@ -38,13 +39,13 @@ func readFile(t *testing.T, path string) string {
 
 func defaultOptions(rootA string, rootB string, stateDir string) Options {
 	return Options{
-		RootAPath:            rootA,
-		RootBPath:            rootB,
-		StateDirectory:       stateDir,
-		IncludeGlob:          "*.md",
-		IgnorePathPrefixes:   []string{".obsidian", ".git", "node_modules", "@eaDir", "#recycle"},
-		IgnoreFileNames:      []string{".Trash*", ".DS_Store", "._*", "Thumbs.db", "desktop.ini"},
-		CreateBackupsOnWrite: true,
+		RootAPath:                   rootA,
+		RootBPath:                   rootB,
+		StateDirectory:              stateDir,
+		IncludeGlob:                 "*.md",
+		IgnorePathPrefixes:          []string{".obsidian", ".git", "node_modules", "@eaDir", "#recycle"},
+		IgnoreFileNames:             []string{".Trash*", ".DS_Store", "._*", "Thumbs.db", "desktop.ini"},
+		CreateBackupsOnWrite:        true,
 		ConflictMtimeEpsilonSeconds: 1.0,
 	}
 }
@@ -174,7 +175,6 @@ func TestIgnores(t *testing.T) {
 	}
 }
 
-func testTime(sec int64) (t time) {
+func testTime(sec int64) time.Time {
 	return time.Unix(sec, 0)
 }
-


### PR DESCRIPTION
## Summary
- move main package to `cmd/filez-sync` so the binary builds as **filez-sync**
- adjust merge temps and tests to use `filez-sync` prefix
- rewrite README to reference `filez-sync` for installation and usage

## Testing
- `go test ./...`
- `go build -o filez-sync ./cmd/filez-sync`


------
https://chatgpt.com/codex/tasks/task_e_689fbbee1f548327a58d067c39db1754