### PR TITLE
Add Docker build/publish workflow and docs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/filez-sync:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.24 AS build
+WORKDIR /src
+COPY go.mod ./
+COPY . .
+RUN go build -o /filez-sync ./cmd/filez-sync
+
+FROM debian:bookworm-slim
+COPY --from=build /filez-sync /usr/local/bin/filez-sync
+ENTRYPOINT ["filez-sync"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ go install ./cmd/filez-sync
 
 This will produce a binary `filez-sync`.
 
+### Docker
+
+A prebuilt image is published to the GitHub Container Registry whenever Go files change on `master`.
+
+```bash
+docker pull ghcr.io/<OWNER>/filez-sync:latest
+docker run --rm \
+  -v /path/to/vault_a:/a \
+  -v /path/to/vault_b:/b \
+  -v /path/to/state:/state \
+  ghcr.io/<OWNER>/filez-sync:latest \
+  /a /b --state-dir /state --include "*.md"
+```
+
+Replace `<OWNER>` with the GitHub username or organization that owns the repository.
+
 ---
 
 ## Usage


### PR DESCRIPTION
## Summary
- build and publish container image to GHCR when Go files change on `master`
- add Dockerfile for building `filez-sync`
- document running via Docker

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fbdcd1ae88327951edc917a08a45f