### PR TITLE
Add configuration and logging tests

### DIFF
--- a/cmd/filez-sync/main_test.go
+++ b/cmd/filez-sync/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,46 +12,80 @@ import (
 )
 
 func TestConfigurationLoadingAndLoggerInit(t *testing.T) {
-	tmp := t.TempDir()
-	cfg := filepath.Join(tmp, "config.yaml")
-	stateDir := filepath.Join(tmp, "state")
-	if err := os.WriteFile(cfg, []byte("state-dir: "+stateDir+"\nlog-level: debug\n"), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
+	cases := []struct {
+		name            string
+		env             map[string]string
+		cfg             string
+		expectNoBackups bool
+		debugEnabled    bool
+	}{
+		{
+			name:            "EnvOverridesConfig",
+			env:             map[string]string{"FILEZ_NO_BACKUPS": "true"},
+			cfg:             "state-dir: %s\nlog-level: debug\nno-backups: false\n",
+			expectNoBackups: true,
+			debugEnabled:    true,
+		},
+		{
+			name:            "ConfigOnly",
+			env:             map[string]string{},
+			cfg:             "state-dir: %s\nlog-level: info\nno-backups: true\n",
+			expectNoBackups: true,
+			debugEnabled:    false,
+		},
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	defer os.Chdir(cwd)
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			cfg := filepath.Join(tmp, "config.yaml")
+			stateDir := filepath.Join(tmp, "state")
+			content := fmt.Sprintf(tc.cfg, stateDir)
+			if err := os.WriteFile(cfg, []byte(content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
 
-	os.Setenv("FILEZ_NO_BACKUPS", "true")
-	defer os.Unsetenv("FILEZ_NO_BACKUPS")
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			defer os.Chdir(cwd)
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatalf("chdir: %v", err)
+			}
 
-	viper.Reset()
-	viper.SetEnvPrefix("FILEZ")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	viper.AutomaticEnv()
-	viper.BindPFlag("state-dir", rootCmd.Flags().Lookup("state-dir"))
-	viper.BindPFlag("include", rootCmd.Flags().Lookup("include"))
-	viper.BindPFlag("no-backups", rootCmd.Flags().Lookup("no-backups"))
-	viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tc.env {
+					os.Unsetenv(k)
+				}
+			}()
 
-	if err := rootCmd.PersistentPreRunE(rootCmd, []string{}); err != nil {
-		t.Fatalf("pre-run: %v", err)
-	}
-	defer func() { logger = nil }()
+			viper.Reset()
+			viper.SetEnvPrefix("FILEZ")
+			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+			viper.AutomaticEnv()
+			viper.BindPFlag("state-dir", rootCmd.Flags().Lookup("state-dir"))
+			viper.BindPFlag("include", rootCmd.Flags().Lookup("include"))
+			viper.BindPFlag("no-backups", rootCmd.Flags().Lookup("no-backups"))
+			viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
 
-	if got := viper.GetString("state-dir"); got != stateDir {
-		t.Fatalf("state-dir not loaded: got %q want %q", got, stateDir)
-	}
-	if !viper.GetBool("no-backups") {
-		t.Fatalf("expected no-backups from env")
-	}
-	if logger == nil || !logger.Core().Enabled(zap.DebugLevel) {
-		t.Fatalf("logger not initialized with debug level")
+			if err := rootCmd.PersistentPreRunE(rootCmd, []string{}); err != nil {
+				t.Fatalf("pre-run: %v", err)
+			}
+			defer func() { logger = nil }()
+
+			if got := viper.GetString("state-dir"); got != stateDir {
+				t.Fatalf("state-dir not loaded: got %q want %q", got, stateDir)
+			}
+			if viper.GetBool("no-backups") != tc.expectNoBackups {
+				t.Fatalf("no-backups=%v, want %v", viper.GetBool("no-backups"), tc.expectNoBackups)
+			}
+			if logger == nil || logger.Core().Enabled(zap.DebugLevel) != tc.debugEnabled {
+				t.Fatalf("debug enabled=%v want %v", logger != nil && logger.Core().Enabled(zap.DebugLevel), tc.debugEnabled)
+			}
+		})
 	}
 }

--- a/cmd/filez-sync/main_test.go
+++ b/cmd/filez-sync/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+func TestConfigurationLoadingAndLoggerInit(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config.yaml")
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.WriteFile(cfg, []byte("state-dir: "+stateDir+"\nlog-level: debug\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(cwd)
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	os.Setenv("FILEZ_NO_BACKUPS", "true")
+	defer os.Unsetenv("FILEZ_NO_BACKUPS")
+
+	viper.Reset()
+	viper.SetEnvPrefix("FILEZ")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+	viper.BindPFlag("state-dir", rootCmd.Flags().Lookup("state-dir"))
+	viper.BindPFlag("include", rootCmd.Flags().Lookup("include"))
+	viper.BindPFlag("no-backups", rootCmd.Flags().Lookup("no-backups"))
+	viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
+
+	if err := rootCmd.PersistentPreRunE(rootCmd, []string{}); err != nil {
+		t.Fatalf("pre-run: %v", err)
+	}
+	defer func() { logger = nil }()
+
+	if got := viper.GetString("state-dir"); got != stateDir {
+		t.Fatalf("state-dir not loaded: got %q want %q", got, stateDir)
+	}
+	if !viper.GetBool("no-backups") {
+		t.Fatalf("expected no-backups from env")
+	}
+	if logger == nil || !logger.Core().Enabled(zap.DebugLevel) {
+		t.Fatalf("logger not initialized with debug level")
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -8,14 +8,27 @@ import (
 )
 
 func TestNewLoggerRespectsLogLevel(t *testing.T) {
-	viper.Set("log-level", "debug")
-	defer viper.Set("log-level", "")
-
-	logger, err := NewLogger()
-	if err != nil {
-		t.Fatalf("NewLogger returned error: %v", err)
+	cases := []struct {
+		name        string
+		level       string
+		enableDebug bool
+	}{
+		{"debug", "debug", true},
+		{"info", "info", false},
 	}
-	if !logger.Core().Enabled(zap.DebugLevel) {
-		t.Fatalf("expected debug level to be enabled")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Set("log-level", tc.level)
+			defer viper.Set("log-level", "")
+
+			logger, err := NewLogger()
+			if err != nil {
+				t.Fatalf("NewLogger returned error: %v", err)
+			}
+			if logger.Core().Enabled(zap.DebugLevel) != tc.enableDebug {
+				t.Fatalf("debug enabled = %v, want %v", logger.Core().Enabled(zap.DebugLevel), tc.enableDebug)
+			}
+		})
 	}
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,21 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+func TestNewLoggerRespectsLogLevel(t *testing.T) {
+	viper.Set("log-level", "debug")
+	defer viper.Set("log-level", "")
+
+	logger, err := NewLogger()
+	if err != nil {
+		t.Fatalf("NewLogger returned error: %v", err)
+	}
+	if !logger.Core().Enabled(zap.DebugLevel) {
+		t.Fatalf("expected debug level to be enabled")
+	}
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -12,16 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func newTempDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", "filez-sync-test-*")
-	if err != nil {
-		t.Fatalf("mkdir temp: %v", err)
-	}
-	return dir
-}
-
-func writeFile(t *testing.T, path string, content string) {
+func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -40,11 +31,11 @@ func readFile(t *testing.T, path string) string {
 	return string(data)
 }
 
-func defaultOptions(rootA string, rootB string, stateDir string) syncpkg.Options {
+func defaultOptions(rootA, rootB, state string) syncpkg.Options {
 	return syncpkg.Options{
 		RootAPath:                   rootA,
 		RootBPath:                   rootB,
-		StateDirectory:              stateDir,
+		StateDirectory:              state,
 		IncludeGlob:                 "*.md",
 		IgnorePathPrefixes:          []string{".obsidian", ".git", "node_modules", "@eaDir", "#recycle"},
 		IgnoreFileNames:             []string{".Trash*", ".DS_Store", "._*", "Thumbs.db", "desktop.ini"},
@@ -53,128 +44,127 @@ func defaultOptions(rootA string, rootB string, stateDir string) syncpkg.Options
 	}
 }
 
-func TestCreateFromSideA(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "Personal", "Note.md"), "hello")
-	opts := defaultOptions(rootA, rootB, stateDir)
-
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
+func TestRunSync(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(t *testing.T, rootA, rootB, state string)
+	}{
+		{
+			name: "CreateFromSideA",
+			run: func(t *testing.T, rootA, rootB, state string) {
+				writeFile(t, filepath.Join(rootA, "Personal", "Note.md"), "hello")
+				opts := defaultOptions(rootA, rootB, state)
+				res, err := syncpkg.RunSync(opts, zap.NewNop())
+				if err != nil {
+					t.Fatalf("sync err: %v", err)
+				}
+				if res.ChangedFileCount != 1 {
+					t.Fatalf("changed count = %d", res.ChangedFileCount)
+				}
+				got := readFile(t, filepath.Join(rootB, "Personal", "Note.md"))
+				if got != "hello" {
+					t.Fatalf("unexpected content: %q", got)
+				}
+			},
+		},
+		{
+			name: "EqualNoChange",
+			run: func(t *testing.T, rootA, rootB, state string) {
+				writeFile(t, filepath.Join(rootA, "a.md"), "same")
+				writeFile(t, filepath.Join(rootB, "a.md"), "same")
+				opts := defaultOptions(rootA, rootB, state)
+				res, err := syncpkg.RunSync(opts, zap.NewNop())
+				if err != nil {
+					t.Fatalf("sync err: %v", err)
+				}
+				if res.ChangedFileCount != 0 {
+					t.Fatalf("expected no changes")
+				}
+			},
+		},
+		{
+			name: "SeedConflictNewerWins",
+			run: func(t *testing.T, rootA, rootB, state string) {
+				writeFile(t, filepath.Join(rootA, "n.md"), "A1")
+				writeFile(t, filepath.Join(rootB, "n.md"), "B1")
+				if runtime.GOOS != "windows" {
+					os.Chtimes(filepath.Join(rootA, "n.md"), testTime(2000), testTime(2000))
+					os.Chtimes(filepath.Join(rootB, "n.md"), testTime(3000), testTime(3000))
+				}
+				opts := defaultOptions(rootA, rootB, state)
+				res, err := syncpkg.RunSync(opts, zap.NewNop())
+				if err != nil {
+					t.Fatalf("sync err: %v", err)
+				}
+				if res.ActionCounters["merge(seed)"] != 1 {
+					t.Fatalf("expected seed merge")
+				}
+				gotA := readFile(t, filepath.Join(rootA, "n.md"))
+				gotB := readFile(t, filepath.Join(rootB, "n.md"))
+				if gotA != gotB {
+					t.Fatalf("sides differ after merge")
+				}
+				if gotB != "B1" && !strings.Contains(gotB, "<<<<<<") {
+					t.Fatalf("unexpected merged content: %q", gotB)
+				}
+			},
+		},
+		{
+			name: "ThreeWayAfterSeed",
+			run: func(t *testing.T, rootA, rootB, state string) {
+				writeFile(t, filepath.Join(rootA, "t.md"), "line1\n")
+				writeFile(t, filepath.Join(rootB, "t.md"), "line1\n")
+				opts := defaultOptions(rootA, rootB, state)
+				if _, err := syncpkg.RunSync(opts, zap.NewNop()); err != nil {
+					t.Fatalf("initial sync: %v", err)
+				}
+				writeFile(t, filepath.Join(rootA, "t.md"), "line1\nA\n")
+				writeFile(t, filepath.Join(rootB, "t.md"), "line1\nB\n")
+				res, err := syncpkg.RunSync(opts, zap.NewNop())
+				if err != nil {
+					t.Fatalf("merge sync: %v", err)
+				}
+				if res.ChangedFileCount != 1 {
+					t.Fatalf("expected one changed file, got %d", res.ChangedFileCount)
+				}
+				merged := readFile(t, filepath.Join(rootA, "t.md"))
+				if !(strings.Contains(merged, "A") || strings.Contains(merged, "B")) {
+					t.Fatalf("merged content not as expected: %q", merged)
+				}
+			},
+		},
+		{
+			name: "Ignores",
+			run: func(t *testing.T, rootA, rootB, state string) {
+				writeFile(t, filepath.Join(rootA, ".obsidian", "state.json"), "{}")
+				writeFile(t, filepath.Join(rootB, ".obsidian", "state.json"), "x")
+				writeFile(t, filepath.Join(rootA, "kept.md"), "K")
+				opts := defaultOptions(rootA, rootB, state)
+				res, err := syncpkg.RunSync(opts, zap.NewNop())
+				if err != nil {
+					t.Fatalf("sync err: %v", err)
+				}
+				if res.ChangedFileCount != 1 {
+					t.Fatalf("expected only one change for kept.md")
+				}
+				data, err := os.ReadFile(filepath.Join(rootB, ".obsidian", "state.json"))
+				if err != nil {
+					t.Fatalf("ignored file missing: %v", err)
+				}
+				if string(data) != "x" {
+					t.Fatalf("ignored file was modified")
+				}
+			},
+		},
 	}
-	if res.ChangedFileCount != 1 {
-		t.Fatalf("changed count = %d", res.ChangedFileCount)
-	}
-	got := readFile(t, filepath.Join(rootB, "Personal", "Note.md"))
-	if got != "hello" {
-		t.Fatalf("unexpected content: %q", got)
-	}
-}
 
-func TestEqualNoChange(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "a.md"), "same")
-	writeFile(t, filepath.Join(rootB, "a.md"), "same")
-
-	opts := defaultOptions(rootA, rootB, stateDir)
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ChangedFileCount != 0 {
-		t.Fatalf("expected no changes")
-	}
-}
-
-func TestSeedConflictNewerWins(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "n.md"), "A1")
-	writeFile(t, filepath.Join(rootB, "n.md"), "B1")
-
-	// ensure distinct mtimes
-	if runtime.GOOS != "windows" {
-		os.Chtimes(filepath.Join(rootA, "n.md"), testTime(2000), testTime(2000))
-		os.Chtimes(filepath.Join(rootB, "n.md"), testTime(3000), testTime(3000))
-	}
-
-	opts := defaultOptions(rootA, rootB, stateDir)
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ActionCounters["merge(seed)"] != 1 {
-		t.Fatalf("expected seed merge")
-	}
-	gotA := readFile(t, filepath.Join(rootA, "n.md"))
-	gotB := readFile(t, filepath.Join(rootB, "n.md"))
-	if gotA != gotB {
-		t.Fatalf("sides differ after merge")
-	}
-	if gotB != "B1" && gotB != "<<<<<<<" {
-		// newer wins unless times equal and markers emitted
-		t.Fatalf("unexpected merged content: %q", gotB)
-	}
-}
-
-func TestThreeWayAfterSeed(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "t.md"), "line1\n")
-	writeFile(t, filepath.Join(rootB, "t.md"), "line1\n")
-
-	opts := defaultOptions(rootA, rootB, stateDir)
-	if _, err := syncpkg.RunSync(opts, zap.NewNop()); err != nil {
-		t.Fatalf("initial sync: %v", err)
-	}
-
-	writeFile(t, filepath.Join(rootA, "t.md"), "line1\nA\n")
-	writeFile(t, filepath.Join(rootB, "t.md"), "line1\nB\n")
-
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("merge sync: %v", err)
-	}
-	if res.ChangedFileCount != 1 {
-		t.Fatalf("expected one changed file, got %d", res.ChangedFileCount)
-	}
-	merged := readFile(t, filepath.Join(rootA, "t.md"))
-	if !(strings.Contains(merged, "A") || strings.Contains(merged, "B")) {
-		t.Fatalf("merged content not as expected: %q", merged)
-	}
-}
-
-func TestIgnores(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, ".obsidian", "state.json"), "{}")
-	writeFile(t, filepath.Join(rootB, ".obsidian", "state.json"), "x")
-	writeFile(t, filepath.Join(rootA, "kept.md"), "K")
-	opts := defaultOptions(rootA, rootB, stateDir)
-
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ChangedFileCount != 1 {
-		t.Fatalf("expected only one change for kept.md")
-	}
-	if _, err := os.Stat(filepath.Join(rootB, ".obsidian", "state.json")); err != nil {
-		// ignored; file should remain as-is without being merged/overwritten
-	} else {
-		// still present, but must not be counted or touched
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rootA := t.TempDir()
+			rootB := t.TempDir()
+			state := t.TempDir()
+			tc.run(t, rootA, rootB, state)
+		})
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,4 +1,4 @@
-package sync
+package sync_test
 
 import (
 	"os"
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	syncpkg "github.com/MarkoPoloResearchLab/file_sync/internal/sync"
 	"go.uber.org/zap"
 )
 
@@ -39,8 +40,8 @@ func readFile(t *testing.T, path string) string {
 	return string(data)
 }
 
-func defaultOptions(rootA string, rootB string, stateDir string) Options {
-	return Options{
+func defaultOptions(rootA string, rootB string, stateDir string) syncpkg.Options {
+	return syncpkg.Options{
 		RootAPath:                   rootA,
 		RootBPath:                   rootB,
 		StateDirectory:              stateDir,
@@ -60,7 +61,7 @@ func TestCreateFromSideA(t *testing.T) {
 	writeFile(t, filepath.Join(rootA, "Personal", "Note.md"), "hello")
 	opts := defaultOptions(rootA, rootB, stateDir)
 
-	res, err := RunSync(opts, zap.NewNop())
+	res, err := syncpkg.RunSync(opts, zap.NewNop())
 	if err != nil {
 		t.Fatalf("sync err: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestEqualNoChange(t *testing.T) {
 	writeFile(t, filepath.Join(rootB, "a.md"), "same")
 
 	opts := defaultOptions(rootA, rootB, stateDir)
-	res, err := RunSync(opts, zap.NewNop())
+	res, err := syncpkg.RunSync(opts, zap.NewNop())
 	if err != nil {
 		t.Fatalf("sync err: %v", err)
 	}
@@ -106,7 +107,7 @@ func TestSeedConflictNewerWins(t *testing.T) {
 	}
 
 	opts := defaultOptions(rootA, rootB, stateDir)
-	res, err := RunSync(opts, zap.NewNop())
+	res, err := syncpkg.RunSync(opts, zap.NewNop())
 	if err != nil {
 		t.Fatalf("sync err: %v", err)
 	}
@@ -133,14 +134,14 @@ func TestThreeWayAfterSeed(t *testing.T) {
 	writeFile(t, filepath.Join(rootB, "t.md"), "line1\n")
 
 	opts := defaultOptions(rootA, rootB, stateDir)
-	if _, err := RunSync(opts, zap.NewNop()); err != nil {
+	if _, err := syncpkg.RunSync(opts, zap.NewNop()); err != nil {
 		t.Fatalf("initial sync: %v", err)
 	}
 
 	writeFile(t, filepath.Join(rootA, "t.md"), "line1\nA\n")
 	writeFile(t, filepath.Join(rootB, "t.md"), "line1\nB\n")
 
-	res, err := RunSync(opts, zap.NewNop())
+	res, err := syncpkg.RunSync(opts, zap.NewNop())
 	if err != nil {
 		t.Fatalf("merge sync: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestIgnores(t *testing.T) {
 	writeFile(t, filepath.Join(rootA, "kept.md"), "K")
 	opts := defaultOptions(rootA, rootB, stateDir)
 
-	res, err := RunSync(opts, zap.NewNop())
+	res, err := syncpkg.RunSync(opts, zap.NewNop())
 	if err != nil {
 		t.Fatalf("sync err: %v", err)
 	}


### PR DESCRIPTION
## Summary
- update sync package tests to import internal path after restructuring
- add logger test ensuring Viper-driven log level is honored
- add configuration test covering Viper env & config file and logger initialization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fc50195688327bbcbf9425f983229