### PR TITLE
Add release workflow for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+  build:
+    needs: create_release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        GOOS: [linux, darwin]
+        GOARCH: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: |
+          GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} CGO_ENABLED=0 \
+            go build -o filez-sync-${{ matrix.GOOS }}-${{ matrix.GOARCH }} ./cmd/filez-sync
+      - name: Archive
+        run: tar -czf filez-sync-${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz \
+          filez-sync-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: filez-sync-${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+          asset_name: filez-sync-${{ matrix.GOOS }}-${{ matrix.GOARCH }}.tar.gz
+          asset_content_type: application/gzip


### PR DESCRIPTION
## Summary
- add release workflow that builds binaries for multiple OS/arch pairs on tagged pushes
- publish release and upload compressed binaries to GitHub release assets

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fccf61a148327992ac67002071f59