### PR TITLE
refactor tests to table style

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -12,9 +12,11 @@ func TestNewLoggerRespectsLogLevel(t *testing.T) {
 		name        string
 		level       string
 		enableDebug bool
+		wantErr     bool
 	}{
-		{"debug", "debug", true},
-		{"info", "info", false},
+		{"debug", "debug", true, false},
+		{"info", "info", false, false},
+		{"invalid", "bogus", false, true},
 	}
 
 	for _, tc := range cases {
@@ -23,6 +25,12 @@ func TestNewLoggerRespectsLogLevel(t *testing.T) {
 			defer viper.Set("log-level", "")
 
 			logger, err := NewLogger()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for log level %q", tc.level)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("NewLogger returned error: %v", err)
 			}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-
 	"github.com/sabhiram/go-gitignore"
 	"go.uber.org/zap"
 
@@ -51,139 +50,12 @@ func defaultOptions(rootA string, rootB string, stateDir string) syncpkg.Options
 	return syncpkg.Options{
 		RootAPath:                   rootA,
 		RootBPath:                   rootB,
-		StateDirectory:              state,
+		StateDirectory:              stateDir,
 		IncludeGlob:                 "*.md",
 		IgnoreMatcher:               ig,
 		CreateBackupsOnWrite:        true,
 		ConflictMtimeEpsilonSeconds: 1.0,
 	}
-}
-
-func TestCreateFromSideA(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "Personal", "Note.md"), "hello")
-	opts := defaultOptions(rootA, rootB, stateDir)
-
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ChangedFileCount != 1 {
-		t.Fatalf("changed count = %d", res.ChangedFileCount)
-	}
-	got := readFile(t, filepath.Join(rootB, "Personal", "Note.md"))
-	if got != "hello" {
-		t.Fatalf("unexpected content: %q", got)
-	}
-}
-
-func TestEqualNoChange(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "a.md"), "same")
-	writeFile(t, filepath.Join(rootB, "a.md"), "same")
-
-	opts := defaultOptions(rootA, rootB, stateDir)
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ChangedFileCount != 0 {
-		t.Fatalf("expected no changes")
-	}
-}
-
-func TestSeedConflictNewerWins(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "n.md"), "A1")
-	writeFile(t, filepath.Join(rootB, "n.md"), "B1")
-
-	// ensure distinct mtimes
-	if runtime.GOOS != "windows" {
-		os.Chtimes(filepath.Join(rootA, "n.md"), testTime(2000), testTime(2000))
-		os.Chtimes(filepath.Join(rootB, "n.md"), testTime(3000), testTime(3000))
-	}
-
-	opts := defaultOptions(rootA, rootB, stateDir)
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ActionCounters["merge(seed)"] != 1 {
-		t.Fatalf("expected seed merge")
-	}
-	gotA := readFile(t, filepath.Join(rootA, "n.md"))
-	gotB := readFile(t, filepath.Join(rootB, "n.md"))
-	if gotA != gotB {
-		t.Fatalf("sides differ after merge")
-	}
-	if gotB != "B1" && gotB != "<<<<<<<" {
-		// newer wins unless times equal and markers emitted
-		t.Fatalf("unexpected merged content: %q", gotB)
-	}
-}
-
-func TestThreeWayAfterSeed(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, "t.md"), "line1\n")
-	writeFile(t, filepath.Join(rootB, "t.md"), "line1\n")
-
-	opts := defaultOptions(rootA, rootB, stateDir)
-	if _, err := syncpkg.RunSync(opts, zap.NewNop()); err != nil {
-		t.Fatalf("initial sync: %v", err)
-	}
-
-	writeFile(t, filepath.Join(rootA, "t.md"), "line1\nA\n")
-	writeFile(t, filepath.Join(rootB, "t.md"), "line1\nB\n")
-
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("merge sync: %v", err)
-	}
-	if res.ChangedFileCount != 1 {
-		t.Fatalf("expected one changed file, got %d", res.ChangedFileCount)
-	}
-	merged := readFile(t, filepath.Join(rootA, "t.md"))
-	if !(strings.Contains(merged, "A") || strings.Contains(merged, "B")) {
-		t.Fatalf("merged content not as expected: %q", merged)
-	}
-}
-
-func TestIgnores(t *testing.T) {
-	rootA := newTempDir(t)
-	rootB := newTempDir(t)
-	stateDir := newTempDir(t)
-
-	writeFile(t, filepath.Join(rootA, ".obsidian", "state.json"), "{}")
-	writeFile(t, filepath.Join(rootB, ".obsidian", "state.json"), "x")
-	writeFile(t, filepath.Join(rootA, ".DS_Store"), "trash")
-	writeFile(t, filepath.Join(rootA, "kept.md"), "K")
-	opts := defaultOptions(rootA, rootB, stateDir)
-
-	res, err := syncpkg.RunSync(opts, zap.NewNop())
-	if err != nil {
-		t.Fatalf("sync err: %v", err)
-	}
-	if res.ChangedFileCount != 1 {
-		t.Fatalf("expected only one change for kept.md")
-	}
-	if _, err := os.Stat(filepath.Join(rootB, ".obsidian", "state.json")); err != nil {
-		// ignored directory
-	}
-	if _, err := os.Stat(filepath.Join(rootB, ".DS_Store")); err == nil {
-		t.Fatalf(".DS_Store should be ignored and not synced")
-    	}
 }
 
 func TestRunSync(t *testing.T) {
@@ -280,6 +152,7 @@ func TestRunSync(t *testing.T) {
 			run: func(t *testing.T, rootA, rootB, state string) {
 				writeFile(t, filepath.Join(rootA, ".obsidian", "state.json"), "{}")
 				writeFile(t, filepath.Join(rootB, ".obsidian", "state.json"), "x")
+				writeFile(t, filepath.Join(rootA, ".DS_Store"), "trash")
 				writeFile(t, filepath.Join(rootA, "kept.md"), "K")
 				opts := defaultOptions(rootA, rootB, state)
 				res, err := syncpkg.RunSync(opts, zap.NewNop())
@@ -295,6 +168,9 @@ func TestRunSync(t *testing.T) {
 				}
 				if string(data) != "x" {
 					t.Fatalf("ignored file was modified")
+				}
+				if _, err := os.Stat(filepath.Join(rootB, ".DS_Store")); err == nil {
+					t.Fatalf(".DS_Store should be ignored and not synced")
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- consolidate sync tests into a single table-driven suite covering creation, equality, conflicts, merges, and ignores
- add invalid log level scenario and error assertion to logger tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fd08431bc8327a5cb79462e8e745f