### PR TITLE
Load ignore rules from external file and remove YAML config

### DIFF
--- a/.filezignore
+++ b/.filezignore
@@ -3,7 +3,7 @@
 .git/
 node_modules/
 @eaDir/
-#recycle/
+\#recycle/
 
 # Files
 .Trash*

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ filez-sync \
 .git/
 node_modules/
 @eaDir/
-#recycle/
+\#recycle/
 
 # Files
 .Trash*

--- a/cmd/filez-sync/main.go
+++ b/cmd/filez-sync/main.go
@@ -84,19 +84,10 @@ func init() {
 	viper.BindPFlag("ignore-file", flags.Lookup("ignore-file"))
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		viper.SetConfigFile("config.yaml")
-		cfgErr := viper.ReadInConfig()
-
 		var err error
 		logger, err = logging.NewLogger()
 		if err != nil {
 			return err
-		}
-
-		if cfgErr != nil {
-			if _, ok := cfgErr.(viper.ConfigFileNotFoundError); !ok {
-				logger.Error("error reading config file", zap.Error(cfgErr))
-			}
 		}
 		return nil
 	}

--- a/cmd/filez-sync/main_test.go
+++ b/cmd/filez-sync/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,81 +10,40 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestConfigurationLoadingAndLoggerInit(t *testing.T) {
-	cases := []struct {
-		name            string
-		env             map[string]string
-		cfg             string
-		expectNoBackups bool
-		debugEnabled    bool
-	}{
-		{
-			name:            "EnvOverridesConfig",
-			env:             map[string]string{"FILEZ_NO_BACKUPS": "true"},
-			cfg:             "state-dir: %s\nlog-level: debug\nno-backups: false\n",
-			expectNoBackups: true,
-			debugEnabled:    true,
-		},
-		{
-			name:            "ConfigOnly",
-			env:             map[string]string{},
-			cfg:             "state-dir: %s\nlog-level: info\nno-backups: true\n",
-			expectNoBackups: true,
-			debugEnabled:    false,
-		},
+func TestEnvironmentLoadingAndLoggerInit(t *testing.T) {
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	os.Setenv("FILEZ_STATE_DIR", stateDir)
+	os.Setenv("FILEZ_NO_BACKUPS", "true")
+	os.Setenv("FILEZ_LOG_LEVEL", "debug")
+	defer func() {
+		os.Unsetenv("FILEZ_STATE_DIR")
+		os.Unsetenv("FILEZ_NO_BACKUPS")
+		os.Unsetenv("FILEZ_LOG_LEVEL")
+	}()
+
+	viper.Reset()
+	viper.SetEnvPrefix("FILEZ")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+	viper.BindPFlag("state-dir", rootCmd.Flags().Lookup("state-dir"))
+	viper.BindPFlag("include", rootCmd.Flags().Lookup("include"))
+	viper.BindPFlag("no-backups", rootCmd.Flags().Lookup("no-backups"))
+	viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
+	viper.BindPFlag("ignore-file", rootCmd.Flags().Lookup("ignore-file"))
+
+	if err := rootCmd.PersistentPreRunE(rootCmd, []string{}); err != nil {
+		t.Fatalf("pre-run: %v", err)
 	}
+	defer func() { logger = nil }()
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tmp := t.TempDir()
-			cfg := filepath.Join(tmp, "config.yaml")
-			stateDir := filepath.Join(tmp, "state")
-			content := fmt.Sprintf(tc.cfg, stateDir)
-			if err := os.WriteFile(cfg, []byte(content), 0o644); err != nil {
-				t.Fatalf("write config: %v", err)
-			}
-
-			cwd, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("getwd: %v", err)
-			}
-			defer os.Chdir(cwd)
-			if err := os.Chdir(tmp); err != nil {
-				t.Fatalf("chdir: %v", err)
-			}
-
-			for k, v := range tc.env {
-				os.Setenv(k, v)
-			}
-			defer func() {
-				for k := range tc.env {
-					os.Unsetenv(k)
-				}
-			}()
-
-			viper.Reset()
-			viper.SetEnvPrefix("FILEZ")
-			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-			viper.AutomaticEnv()
-			viper.BindPFlag("state-dir", rootCmd.Flags().Lookup("state-dir"))
-			viper.BindPFlag("include", rootCmd.Flags().Lookup("include"))
-			viper.BindPFlag("no-backups", rootCmd.Flags().Lookup("no-backups"))
-			viper.BindPFlag("log-level", rootCmd.Flags().Lookup("log-level"))
-
-			if err := rootCmd.PersistentPreRunE(rootCmd, []string{}); err != nil {
-				t.Fatalf("pre-run: %v", err)
-			}
-			defer func() { logger = nil }()
-
-			if got := viper.GetString("state-dir"); got != stateDir {
-				t.Fatalf("state-dir not loaded: got %q want %q", got, stateDir)
-			}
-			if viper.GetBool("no-backups") != tc.expectNoBackups {
-				t.Fatalf("no-backups=%v, want %v", viper.GetBool("no-backups"), tc.expectNoBackups)
-			}
-			if logger == nil || logger.Core().Enabled(zap.DebugLevel) != tc.debugEnabled {
-				t.Fatalf("debug enabled=%v want %v", logger != nil && logger.Core().Enabled(zap.DebugLevel), tc.debugEnabled)
-			}
-		})
+	if got := viper.GetString("state-dir"); got != stateDir {
+		t.Fatalf("state-dir not loaded: got %q want %q", got, stateDir)
+	}
+	if !viper.GetBool("no-backups") {
+		t.Fatalf("no-backups flag not loaded")
+	}
+	if logger == nil || !logger.Core().Enabled(zap.DebugLevel) {
+		t.Fatalf("debug logging not enabled")
 	}
 }

--- a/internal/sync/ignore_test.go
+++ b/internal/sync/ignore_test.go
@@ -1,0 +1,44 @@
+package sync
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sabhiram/go-gitignore"
+)
+
+func TestShouldIgnore(t *testing.T) {
+	ig, err := ignore.CompileIgnoreFile(filepath.Join("..", "..", ".filezignore"))
+	if err != nil {
+		t.Fatalf("compile ignore file: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		path   string
+		isDir  bool
+		expect bool
+	}{
+		{"ObsidianDir", ".obsidian", true, true},
+		{"ObsidianFile", ".obsidian/state.json", false, true},
+		{"GitDir", ".git", true, true},
+		{"NodeModulesDir", "node_modules", true, true},
+		{"SynologyDir", "@eaDir", true, true},
+		{"RecycleDir", "#recycle", true, true},
+		{"TrashFile", ".Trash-123", false, true},
+		{"DSStore", ".DS_Store", false, true},
+		{"AppleDouble", "._foo", false, true},
+		{"Thumbs", "Thumbs.db", false, true},
+		{"DesktopIni", "desktop.ini", false, true},
+		{"RegularFile", "notes/readme.md", false, false},
+		{"RegularDir", "notes", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldIgnore(tc.path, tc.isDir, ig); got != tc.expect {
+				t.Fatalf("shouldIgnore(%q, %v) = %v, want %v", tc.path, tc.isDir, got, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- eliminate `config.yaml` dependency and streamline startup
- load ignore patterns from `.filezignore`
- add table-driven tests covering all ignore rules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fd26f914883279b8966e3f6d234de