### PR TITLE
Rename utility to zync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM golang:1.24 AS build
 WORKDIR /src
 COPY go.mod ./
 COPY . .
-RUN go build -o /filez-sync ./cmd/filez-sync
+RUN go build -o /zync ./cmd/zync
 
 FROM debian:bookworm-slim
-COPY --from=build /filez-sync /usr/local/bin/filez-sync
-ENTRYPOINT ["filez-sync"]
+COPY --from=build /zync /usr/local/bin/zync
+ENTRYPOINT ["zync"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# filez-sync
+# zync
 
-`filez-sync` is a standalone Go tool for **bidirectional file synchronization** with proper **3-way merges** for Markdown (or any other text) files, designed to replace `unison` for cases where you need:
+`zync` is a standalone Go tool for **bidirectional file synchronization** with proper **3-way merges** for Markdown (or any other text) files, designed to replace `unison` for cases where you need:
 
 * Persistent merge history (per-file ancestor snapshots)
 * Automatic use of `diff3` for conflict resolution
@@ -24,26 +24,26 @@ Designed for syncing any two directories without assumptions about their content
 
 ## Usage
 
-You can obtain and run `filez-sync` in several ways.
+You can obtain and run `zync` in several ways.
 
 ### Install with Go
 
 Requires Go 1.24+ and optionally GNU `diff3` in your `PATH`.
 
 ```bash
-go install github.com/MarkoPoloResearchLab/file_sync/cmd/filez-sync@latest
+go install github.com/MarkoPoloResearchLab/zync/cmd/zync@latest
 ```
 
 The binary will be placed in `$(go env GOPATH)/bin` (or `GOBIN` if set).
 
 ### Download Prebuilt Binaries
 
-Precompiled binaries are available on the [releases page](https://github.com/MarkoPoloResearchLab/file_sync/releases).
+Precompiled binaries are available on the [releases page](https://github.com/MarkoPoloResearchLab/zync/releases).
 For example, on Linux x86_64:
 
 ```bash
-curl -L https://github.com/MarkoPoloResearchLab/file_sync/releases/latest/download/filez-sync_Linux_x86_64.tar.gz | tar -xz
-sudo mv filez-sync /usr/local/bin/
+curl -L https://github.com/MarkoPoloResearchLab/zync/releases/latest/download/zync_Linux_x86_64.tar.gz | tar -xz
+sudo mv zync /usr/local/bin/
 ```
 
 ### Docker Image
@@ -51,12 +51,12 @@ sudo mv filez-sync /usr/local/bin/
 A prebuilt image is published to the GitHub Container Registry whenever Go files change on `master`.
 
 ```bash
-docker pull ghcr.io/<OWNER>/filez-sync:latest
+docker pull ghcr.io/<OWNER>/zync:latest
 docker run --rm \
   -v /path/to/dir_a:/a \
   -v /path/to/dir_b:/b \
   -v /path/to/state:/state \
-  ghcr.io/<OWNER>/filez-sync:latest \
+  ghcr.io/<OWNER>/zync:latest \
   /a /b --state-dir /state
 ```
 
@@ -65,11 +65,11 @@ Replace `<OWNER>` with the GitHub username or organization that owns the reposit
 ### CLI
 
 ```bash
-filez-sync /path/to/dir_a /path/to/dir_b \
+zync /path/to/dir_a /path/to/dir_b \
   --state-dir /path/to/state
 ```
 
-By default, `filez-sync` walks both directories **recursively** and
+By default, `zync` walks both directories **recursively** and
 synchronizes all files because `--include` defaults to `*`. The pattern
 supplied to `--include` is matched against each file's relative path and file
 name. Provide a more restrictive glob to limit which files are synchronized.
@@ -77,7 +77,7 @@ For example, to sync only Markdown files, use `--include "*.md"`.
 
 ```bash
 # Only sync Markdown files
-filez-sync /path/to/dir_a /path/to/dir_b \
+zync /path/to/dir_a /path/to/dir_b \
   --state-dir /path/to/state \
   --include "*.md"
 ```
@@ -114,10 +114,10 @@ filez-sync /path/to/dir_a /path/to/dir_b \
 ## Example
 
 ```bash
-filez-sync \
+zync \
   ~/Documents/ProjectA \
   /mnt/backup/ProjectA \
-  --state-dir ~/.filez-sync-state
+  --state-dir ~/.zync-state
 ```
 
 ---

--- a/cmd/zync/main.go
+++ b/cmd/zync/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/MarkoPoloResearchLab/file_sync/internal/logging"
-	syncpkg "github.com/MarkoPoloResearchLab/file_sync/internal/sync"
+        "github.com/MarkoPoloResearchLab/zync/internal/logging"
+        syncpkg "github.com/MarkoPoloResearchLab/zync/internal/sync"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -15,7 +15,7 @@ import (
 var (
 	logger  *zap.Logger
 	rootCmd = &cobra.Command{
-		Use:   "filez-sync [flags] <root_a> <root_b>",
+                Use:   "zync [flags] <root_a> <root_b>",
 		Short: "Synchronize files between two directories",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -76,7 +76,7 @@ func init() {
 	flags.Bool("no-backups", false, "disable .bak files when overwriting")
 	flags.String("log-level", "info", "log level")
 
-	viper.SetEnvPrefix("FILEZ")
+        viper.SetEnvPrefix("ZYNC")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 

--- a/cmd/zync/main_test.go
+++ b/cmd/zync/main_test.go
@@ -21,7 +21,7 @@ func TestConfigurationLoadingAndLoggerInit(t *testing.T) {
 	}{
 		{
 			name:            "EnvOverridesConfig",
-			env:             map[string]string{"FILEZ_NO_BACKUPS": "true"},
+                        env:             map[string]string{"ZYNC_NO_BACKUPS": "true"},
 			cfg:             "state-dir: %s\nlog-level: debug\nno-backups: false\n",
 			expectNoBackups: true,
 			debugEnabled:    true,
@@ -64,7 +64,7 @@ func TestConfigurationLoadingAndLoggerInit(t *testing.T) {
 			}()
 
 			viper.Reset()
-			viper.SetEnvPrefix("FILEZ")
+                        viper.SetEnvPrefix("ZYNC")
 			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 			viper.AutomaticEnv()
 			viper.BindPFlag("state-dir", rootCmd.Flags().Lookup("state-dir"))

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MarkoPoloResearchLab/file_sync
+module github.com/MarkoPoloResearchLab/zync
 
 go 1.24.6
 

--- a/internal/sync/merge.go
+++ b/internal/sync/merge.go
@@ -44,7 +44,7 @@ func mergeWithDiff3(diff3Path string, base []byte, sideA []byte, sideB []byte) (
 	if diff3Path == "" {
 		return nil, false
 	}
-	tempDir, tempErr := os.MkdirTemp("", "filez-sync-merge-*")
+        tempDir, tempErr := os.MkdirTemp("", "zync-merge-*")
 	if tempErr != nil {
 		return nil, false
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	syncpkg "github.com/MarkoPoloResearchLab/file_sync/internal/sync"
+        syncpkg "github.com/MarkoPoloResearchLab/zync/internal/sync"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
## Summary
- rename project, CLI command, and module path from filez-sync to zync
- update environment prefixes, merge temp directory, and related tests
- revise Dockerfile and documentation for new binary name

## Testing
- `go build ./cmd/zync`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0cda274ac8327b7e1044473b94e06